### PR TITLE
Improve string with multilines

### DIFF
--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -60,9 +60,12 @@ private:
             auto s = mrb_value_to_scalar(obj);
             *node = s;
 
-            if (s.find("\n") == c4::yml::npos) {
+            if (s.find("\n") == c4::yml::npos)
+            {
                 *node |= ryml::VAL | ryml::VAL_PLAIN;
-            } else {
+            }
+            else
+            {
                 *node |= ryml::VAL | ryml::VAL_LITERAL;
             }
             return NULL;
@@ -109,6 +112,11 @@ private:
                 }
                 c << ryml::key(k);
                 c |= ryml::KEY_PLAIN;
+
+                if (k.find("\n") != c4::yml::npos)
+                {
+                    c |= ryml::KEY_LITERAL;
+                }
 
                 auto exc = mrb_value_to_yaml(value, &c);
                 if (exc != NULL)

--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -57,8 +57,14 @@ private:
         mrb_vtype t = mrb_type(obj);
         if (mrb_nil_p(obj) || t == MRB_TT_TRUE || t == MRB_TT_FALSE || t == MRB_TT_INTEGER || t == MRB_TT_FLOAT || t == MRB_TT_STRING)
         {
-            *node |= ryml::VAL | ryml::VAL_PLAIN;
-            *node = mrb_value_to_scalar(obj);
+            auto s = mrb_value_to_scalar(obj);
+            *node = s;
+
+            if (s.find("\n") == c4::yml::npos) {
+                *node |= ryml::VAL | ryml::VAL_PLAIN;
+            } else {
+                *node |= ryml::VAL | ryml::VAL_LITERAL;
+            }
             return NULL;
         }
 

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -7,7 +7,26 @@ assert('YAML.#dump') do
   assert_equal('.nan', YAML.dump(Float::NAN), 'nan')
   assert_equal('-.inf', YAML.dump(-Float::INFINITY), '-inf')
   assert_equal('.inf', YAML.dump(Float::INFINITY), 'inf')
-  assert_equal('hello', YAML.dump('hello'), 'String')
+
+  assert('String') do
+    assert_equal('hello', YAML.dump('hello'), 'single line')
+    assert_equal(<<~YAML.chomp, "hello\nworld".to_yaml, 'multiple lines')
+      |-
+        hello
+        world
+    YAML
+    assert_equal(<<~YAML.chomp, "hello\nworld\n".to_yaml, 'end with newline')
+      |
+        hello
+        world
+    YAML
+    assert_equal(<<~YAML.chomp, "  hello\nworld".to_yaml, 'start with space')
+      |2-
+          hello
+        world
+    YAML
+  end
+
   assert_equal("- 1\n- 2\n- 3", YAML.dump([1, 2, 3]), 'Array')
   assert_equal("name: Alice\nage: 30", YAML.dump({ 'name' => 'Alice', 'age' => 30 }), 'Hash')
 

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -27,8 +27,25 @@ assert('YAML.#dump') do
     YAML
   end
 
-  assert_equal("- 1\n- 2\n- 3", YAML.dump([1, 2, 3]), 'Array')
-  assert_equal("name: Alice\nage: 30", YAML.dump({ 'name' => 'Alice', 'age' => 30 }), 'Hash')
+  assert('Array') do
+    assert_equal("- 1\n- 2\n- 3", YAML.dump([1, 2, 3]), 'single line')
+    assert_equal(<<~YAML.chomp, YAML.dump(["a\nb"]), 'multiple lines')
+      - |-
+        a
+        b
+    YAML
+  end
+
+  assert('Hash') do
+    assert_equal("name: Alice\nage: 30", YAML.dump({ 'name' => 'Alice', 'age' => 30 }), 'simple key-value')
+
+    assert_equal(<<~YAML.chomp, YAML.dump({ "a\nb" => 'cd' }), 'key with newline')
+      ? |-
+        a
+        b
+      : cd
+    YAML
+  end
 
   assert('colorize') do
     assert_equal('null'.gray, YAML.dump(nil, colorize: true), 'nil')


### PR DESCRIPTION
改行が含まれているときの `YAML#dump`の処理を改善した