### PR TITLE
Add support explict key

### DIFF
--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -222,6 +222,16 @@ assert('YAML.#load') do
       ? {"foo": "bar"}
       : foobar
     YAML
+
+    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with multiple keys')
+      ? - foo
+        - bar
+      : baz
+    YAML
+    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with multiple keys')
+      ? [foo, bar]
+      : baz
+    YAML
   end
 
   assert_raise_with_message(YAML::SyntaxError, 'ERROR: missing terminating ]') { YAML.load('[') }

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -214,16 +214,14 @@ assert('YAML.#load') do
     assert_equal({ %w[foo bar] => 'foobar' }, YAML.load('[foo, bar]: foobar'), 'Hash with Array key (flow style)')
     assert_equal({ { 'foo' => 'bar' } => 'foobar' }, YAML.load('{foo: bar}: foobar'), 'Hash with Hash key')
 
-    skip('Hash with explicit key is not supported yet') do
-      assert_equal({ { 'foo' => 'bar' } => 'foobar' }, YAML.load(<<~YAML), 'Hash with explicit key')
-        ? foo: bar
-        : foobar
-      YAML
-      assert_equal({ { 'foo' => 'bar' } => 'foobar' }, YAML.load(<<~YAML), 'Hash with explicit key (flow style)')
-        ? {"foo": "bar"}
-        : foobar
-      YAML
-    end
+    assert_equal({ { 'foo' => 'bar' } => 'foobar' }, YAML.load(<<~YAML), 'Hash with explicit key')
+      ? foo: bar
+      : foobar
+    YAML
+    assert_equal({ { 'foo' => 'bar' } => 'foobar' }, YAML.load(<<~YAML), 'Hash with explicit key (flow style)')
+      ? {"foo": "bar"}
+      : foobar
+    YAML
   end
 
   assert_raise_with_message(YAML::SyntaxError, 'ERROR: missing terminating ]') { YAML.load('[') }

--- a/test/yaml.rb
+++ b/test/yaml.rb
@@ -223,12 +223,12 @@ assert('YAML.#load') do
       : foobar
     YAML
 
-    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with multiple keys')
+    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with Array key (block style)')
       ? - foo
         - bar
       : baz
     YAML
-    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with multiple keys')
+    assert_equal({ %w[foo bar] => 'baz' }, YAML.load(<<~YAML), 'Hash with Array key (flow style)')
       ? [foo, bar]
       : baz
     YAML


### PR DESCRIPTION
`?` で始まるマップのキーをサポートします

```yaml
? {foo: bar}
: baz
```